### PR TITLE
update to all files for automated passing of outputs to next stages

### DIFF
--- a/TCL/snapshot1.tcl
+++ b/TCL/snapshot1.tcl
@@ -42,7 +42,7 @@ foreach dcd_in $dcd_list {
   mol addfile $dcd_in first 0 last -1 step $interval waitfor -1
 
   if { $frameFirst eq "first" } {
-    set frameFirst 1
+    set frameFirst 0
   }
     
   if { $frameLast eq "last" } {

--- a/TCL/snapshot1.tcl
+++ b/TCL/snapshot1.tcl
@@ -8,25 +8,23 @@
 # Check cms
 set strucs     APDB
 set dcd_list  ADCD 
-set interval  1 
 set CUTOFF1   CUTOFF
 set PROBE     AAA
 set RESID     BBB
 set CHAIN     CCC
+set interval  1
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  0} {set strucs [split [lindex $argv $index] ,]}
   if {$index eq  1} {set dcd_list [split [lindex $argv $index] ,]}
-  if {$index eq  2} {set interval [lindex $argv $index]}
-  if {$index eq  3} {set CUTOFF1 [lindex $argv $index]}
-  if {$index eq  4} {set PROBE [lindex $argv $index]}
-  if {$index eq  5} {set RESID [lindex $argv $index]}
-  if {$index eq  6} {set CHAIN [lindex $argv $index]}
-  if {$index eq  7} {set TRJNUM [split [lindex $argv $index] ,]}
+  if {$index eq  2} {set CUTOFF1 [lindex $argv $index]}
+  if {$index eq  3} {set PROBE [lindex $argv $index]}
+  if {$index eq  4} {set RESID [lindex $argv $index]}
+  if {$index eq  5} {set CHAIN [lindex $argv $index]}
 }
 
-set TRJNUM 0
+set TRJNUM 1
 foreach dcd_in $dcd_list {
   set ofile [open ligbo-$TRJNUM.dat w]
   set count 0

--- a/TCL/snapshot1.tcl
+++ b/TCL/snapshot1.tcl
@@ -6,18 +6,17 @@
 
 
 # Check cms
-set struc      APDB
-set dcd_list { ADCD }
-set interval SSTEP 
-set CUTOFF1 CUTOFF
-set PROBE AAA
-set RESID BBB
-set CHAIN CCC
-set TRJNUM RRR
+set strucs     APDB
+set dcd_list  ADCD 
+set interval  1 
+set CUTOFF1   CUTOFF
+set PROBE     AAA
+set RESID     BBB
+set CHAIN     CCC
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
-  if {$index eq  0} {set struc [split [lindex $argv $index] ,]}
+  if {$index eq  0} {set strucs [split [lindex $argv $index] ,]}
   if {$index eq  1} {set dcd_list [split [lindex $argv $index] ,]}
   if {$index eq  2} {set interval [lindex $argv $index]}
   if {$index eq  3} {set CUTOFF1 [lindex $argv $index]}
@@ -27,16 +26,19 @@ for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  7} {set TRJNUM [split [lindex $argv $index] ,]}
 }
 
-set ofile [open ligbo-$TRJNUM.dat w]
-set count 0
-
-#write a header for the datafile 
-#  puts $ofile "#frame    Calpha_dist    N-O_dist    N-O_dist    N-O_dist    N-O_dist    N-O_dist    N-O_dist"
-
+set TRJNUM 0
 foreach dcd_in $dcd_list {
+  set ofile [open ligbo-$TRJNUM.dat w]
+  set count 0
+
+  if { [llength $strucs] > 1 } {
+    set struc [lindex $strucs $dcdNum]
+  } else {
+    set struc $strucs
+  }
 
   mol load pdb $struc
-  mol addfile $dcd_in type dcd first 0 last -1 step $interval waitfor -1
+  mol addfile $dcd_in first 0 last -1 step $interval waitfor -1
 
   ##### alignment
   set ref_molid [molinfo top get id]
@@ -98,8 +100,11 @@ foreach dcd_in $dcd_list {
   }
   #end loop over frames
   animate delete all
+
+  flush $ofile
+  close $ofile
+  incr TRJNUM
 }
-#end dtr list
-flush $ofile
-close $ofile
+# end loop of trajectories
+
 exit

--- a/TCL/snapshot1.tcl
+++ b/TCL/snapshot1.tcl
@@ -13,6 +13,8 @@ set PROBE     AAA
 set RESID     BBB
 set CHAIN     CCC
 set interval  1
+set frameFirst first
+set frameLast last
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
@@ -22,12 +24,13 @@ for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  3} {set PROBE [lindex $argv $index]}
   if {$index eq  4} {set RESID [lindex $argv $index]}
   if {$index eq  5} {set CHAIN [lindex $argv $index]}
+  if {$index eq  6} {set frameFirst [lindex $argv $index]}
+  if {$index eq  7} {set frameLast [lindex $argv $index]}
 }
 
 set TRJNUM 1
 foreach dcd_in $dcd_list {
   set ofile [open ligbo-$TRJNUM.dat w]
-  set count 0
 
   if { [llength $strucs] > 1 } {
     set struc [lindex $strucs $dcdNum]
@@ -38,6 +41,14 @@ foreach dcd_in $dcd_list {
   mol load pdb $struc
   mol addfile $dcd_in first 0 last -1 step $interval waitfor -1
 
+  if { $frameFirst eq "first" } {
+    set frameFirst 1
+  }
+    
+  if { $frameLast eq "last" } {
+    set frameLast [molinfo top get numframes]
+  }
+
   ##### alignment
   set ref_molid [molinfo top get id]
   set traj_molid [molinfo top get id]
@@ -47,15 +58,9 @@ foreach dcd_in $dcd_list {
   set CAcompare [atomselect $traj_molid $calpha]
   set allsys "all"
   set allsysC [atomselect $traj_molid $allsys]
-  ##### alignment
+  ##### alignment 
 
-
-  set first_frame 0
-  set num_frames [molinfo top get numframes] 
-
-  for {set f $first_frame} {$f < $num_frames} {incr f} {
-    incr count
-    set time [expr ($count-1)*$interval]
+  for {set f $frameFirst} {$f < $frameLast} {incr f} {
     molinfo top set frame $f
 
     ##### alignment

--- a/TCL/snapshot2.tcl
+++ b/TCL/snapshot2.tcl
@@ -7,17 +7,16 @@ set ofile [open _ligbo-ok.dat w]
 # Check cms
 set input    ./v-com-ok.pdb
 
-set interval SSTEP 
+set interval 1 
 set CUTOFF CUTOFF
 set PROBE AAA
 set hotspotNum FF
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
-  if {$index eq  0} {set interval [lindex $argv $index]}
-  if {$index eq  1} {set CUTOFF [lindex $argv $index]}
-  if {$index eq  2} {set PROBE [lindex $argv $index]}
-  if {$index eq  3} {set hotspotNum [lindex $argv $index]}
+  if {$index eq  0} {set CUTOFF [lindex $argv $index]}
+  if {$index eq  1} {set PROBE [lindex $argv $index]}
+  if {$index eq  2} {set hotspotNum [lindex $argv $index]}
 }
 
 set count 0

--- a/TCL/snapshot2.tcl
+++ b/TCL/snapshot2.tcl
@@ -23,7 +23,7 @@ for {set index 0} {$index < $argc -1} {incr index} {
 animate read pdb ./v-com-ok.pdb beg 0 end -1 skip 1 waitfor all
 
 if { $frameFirst eq "first" } {
-  set frameFirst 1
+  set frameFirst 0
 }
   
 if { $frameLast eq "last" } {

--- a/TCL/snapshot2.tcl
+++ b/TCL/snapshot2.tcl
@@ -4,30 +4,33 @@
 # Druggability molecular dynamics simulations
 
 set ofile [open _ligbo-ok.dat w]
-# Check cms
-set input    ./v-com-ok.pdb
 
-set interval 1 
 set CUTOFF CUTOFF
 set PROBE AAA
 set hotspotNum FF
+set frameFirst first
+set frameLast last
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  0} {set CUTOFF [lindex $argv $index]}
   if {$index eq  1} {set PROBE [lindex $argv $index]}
   if {$index eq  2} {set hotspotNum [lindex $argv $index]}
+  if {$index eq  3} {set frameFirst [lindex $argv $index]}
+  if {$index eq  4} {set frameLast [lindex $argv $index]}
 }
 
-set count 0
-animate read pdb $input beg 0 end -1 skip $interval waitfor all
+animate read pdb ./v-com-ok.pdb beg 0 end -1 skip 1 waitfor all
 
-set first_frame 0
-set num_frames [molinfo top get numframes] 
+if { $frameFirst eq "first" } {
+  set frameFirst 1
+}
+  
+if { $frameLast eq "last" } {
+  set frameLast [molinfo top get numframes]
+}
 
-for {set f $first_frame} {$f < $num_frames} {incr f} {
-	incr count
-	set time [expr ($count-1)*$interval]
+for {set f $frameFirst} {$f < $frameLast} {incr f} {
 	molinfo top set frame $f
 
   set gluOxy [atomselect top "resname $PROBE and chain P and not hydrogen"]
@@ -41,7 +44,7 @@ for {set f $first_frame} {$f < $num_frames} {incr f} {
 	foreach atom1 $Olist {
 		foreach atom2 $Nlist {
 			set NOdist [measure bond [list [list $atom1] [list $atom2]]]
-      if {$NOdist < $CUTOFF } {
+      if { $NOdist < $CUTOFF } {
         set NNNN [expr $NNNN+1]
         set aato1 [expr $atom1+1]
         set aato2 [expr $atom2+1]

--- a/TCL/snapshot3.tcl
+++ b/TCL/snapshot3.tcl
@@ -3,8 +3,8 @@
 # Write PDB files for selected snapshots with dominant interactions from
 # Druggability molecular dynamics simulations
 
-set pdbfile APDB
-set dcdfile ADCD
+set strucs APDB
+set traj_list ADCD
 set interval SSTEP
 set FRAME AAA
 set PROBE BBB
@@ -13,8 +13,8 @@ set RRR FF
 
 # Take parameter values from input arguments as far as possible
 for {set index 0} {$index < $argc -1} {incr index} {
-  if {$index eq  0} {set pdbfile [lindex $argv $index]}
-  if {$index eq  1} {set dcdfile [lindex $argv $index]}
+  if {$index eq  0} {set strucs [lindex $argv $index]}
+  if {$index eq  1} {set traj_list [lindex $argv $index]}
   if {$index eq  2} {set interval [lindex $argv $index]}
   if {$index eq  3} {set FRAME [lindex $argv $index]}
   if {$index eq  4} {set PROBE [lindex $argv $index]}
@@ -22,8 +22,16 @@ for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  6} {set RRR [lindex $argv $index]}
 }
 
-mol load pdb $pdbfile 
-mol addfile  $dcdfile type dcd first 0 last -1 step $interval waitfor -1
+foreach trajFile $traj_list {
+
+  if { [llength $strucs] > 1 } {
+    set struc [lindex $strucs $dcdNum]
+  } else {
+    set struc $strucs
+  }
+
+mol load pdb $struc 
+mol addfile  $trajFile first 0 last -1 step $interval waitfor -1
 
 animate write pdb pro-$RRR-$FRAME.pdb beg $FRAME end $FRAME waitfor all sel [atomselect top "protein"]
 animate write pdb lig-$RRR-$FRAME-$PROBE-$RESID.pdb beg $FRAME end $FRAME waitfor all sel [atomselect top "resname $PROBE and resid $RESID"]

--- a/TCL/snapshot3.tcl
+++ b/TCL/snapshot3.tcl
@@ -5,7 +5,6 @@
 
 set strucs APDB
 set traj_list ADCD
-set interval SSTEP
 set FRAME AAA
 set PROBE BBB
 set RESID CCC
@@ -15,11 +14,10 @@ set RRR FF
 for {set index 0} {$index < $argc -1} {incr index} {
   if {$index eq  0} {set strucs [lindex $argv $index]}
   if {$index eq  1} {set traj_list [lindex $argv $index]}
-  if {$index eq  2} {set interval [lindex $argv $index]}
-  if {$index eq  3} {set FRAME [lindex $argv $index]}
-  if {$index eq  4} {set PROBE [lindex $argv $index]}
-  if {$index eq  5} {set RESID [lindex $argv $index]}
-  if {$index eq  6} {set RRR [lindex $argv $index]}
+  if {$index eq  2} {set FRAME [lindex $argv $index]}
+  if {$index eq  3} {set PROBE [lindex $argv $index]}
+  if {$index eq  4} {set RESID [lindex $argv $index]}
+  if {$index eq  5} {set RRR [lindex $argv $index]}
 }
 
 foreach trajFile $traj_list {
@@ -31,9 +29,11 @@ foreach trajFile $traj_list {
   }
 
 mol load pdb $struc 
-mol addfile  $trajFile first 0 last -1 step $interval waitfor -1
+mol addfile  $trajFile first 0 last -1 step 1 waitfor -1
 
 animate write pdb pro-$RRR-$FRAME.pdb beg $FRAME end $FRAME waitfor all sel [atomselect top "protein"]
 animate write pdb lig-$RRR-$FRAME-$PROBE-$RESID.pdb beg $FRAME end $FRAME waitfor all sel [atomselect top "resname $PROBE and resid $RESID"]
+
+}
 
 exit

--- a/siteselection.sh
+++ b/siteselection.sh
@@ -1,23 +1,20 @@
 #!/bin/bash
 
 CL=8                               # cutoff to include hot spots
-hotspotsFile='all'                 # file/directory path for hotspots PDB
-highaffresidsFile='highaffresid'   # file/directory path for highaffresids.dat
+hotspotsFile='site-list.dat'       # file/directory path for hotspots PDB
+highaffresidsFile='site-list.dat'   # file/directory path for highaffresids.dat
 proteinFile='struc-list.dat'       # file/directory for protein PDB
 CHAIN='chain-list.dat'             # chain IDs
 PROBE='probe-list.dat'             # probe types
-#dir is not set as it will follow highaffresidsFile if the user doesn't provide it
 
 if [[ $1 = "help" ]]; then
   echo "This script takes 6 arguments in the following order:"
   echo ""
-  echo "cutoff length for hot spots being near high affinity residues, "
-  echo ""
   echo "path to hotspots file or directory containing it, "
   echo ""
-  echo "path to highaffresid file or directory containing it, "
+  echo "cutoff length for hot spots being near high affinity residues, "
   echo ""
-  echo "path to directory for output, "
+  echo "path to highaffresid file or directory containing it, "
   echo ""
   echo "path to PDB structure or directory containing it, "
   echo ""
@@ -31,140 +28,161 @@ if [[ $1 = "help" ]]; then
   echo "When results are calculated for multiple sites/regions, we use the best one by default."
   echo "All of them can be used by providing the word 'all' for hotspots file."
   echo "Please note that if no value is provided for highaffresid path, the hotspots path value is used."
+  echo ""
   exit
 fi
 
 
 for arg in `seq 1 "$#"`; do
   if [[ "$arg" -eq 1 ]]; then
-    CL=$1
+    hotspotsFile=$1
   elif [[ "$arg" -eq 2 ]]; then
-    hotspotsFile=$2
+    CL=$2
   elif [[ "$arg" -eq 3 ]]; then
     highaffresidsFile=$3
   elif [[ "$arg" -eq 4 ]]; then
-    dir=$4
+    proteinFile=$4
   elif [[ "$arg" -eq 5 ]]; then
-    proteinFile=$5
+    CHAIN=$5
   elif [[ "$arg" -eq 6 ]]; then
-    CHAIN=$6
-  elif [[ "$arg" -eq 7 ]]; then
-    PROBE=$7
+    PROBE=$6
   fi
 done
 
-echo "CL is set to $CL"
-echo ""
+# Check where site-list.dat exists
 
-# Set hotspotsFile to point to actual directory
+[ -f site-list.dat ] && siteListExists=1 || siteListExists=0
 
-echo "hotspotsFile is set to $hotspotsFile"
-
-if [[ $hotspotsFile = "all" ]]; then
-  hotspotsFile=`du -d 1 | awk '{ print $2 }' | head -n -1`
-fi
-
-if [[ $hotspotsFile = "best" ]]; then
-  hotspotsFile='best-site'
-fi
-
-echo "hotspotsFile is set to contain"
-for file in $hotspotsFile; do
-  echo $file
-done
-echo ""
-
-# Set highaffresids to point to actual files
-
-if [ -z ${highaffresidsFile+x} ]; then 
-  highaffresidsFile=$hotspotsFile
-else
-  if [[ $highaffresidsFile = "all" ]]; then
-    highaffresidsFile=`du -d 1 | awk '{ print $2 }' | head -n -1`
-  fi
-
-  if [[ $highaffresidsFile = "best" ]]; then
-    highaffresidsFile='best-site'
-  fi
-fi
-
-highaffresidsDirs=()
-isDir=0
-for file in $highaffresidsFile; do
-  if [[ -d $file ]]; then
-    highaffresidsDirs+=($file)
-    isDir=1
+# Make sure we have valid hot spots files
+#############################################################
+if [[ $hotspotsFile = "site-list.dat" ]]; then
+  if [[ $siteListExists -eq 1 ]]; then
+    hotspotsFile=`cat $hotspotsFile`
   else
-    break
+    hotspotsFile=''
   fi
-done
-
-if [[ "$isDir" -eq 1 ]]; then
-  highaffresidsFileList=${highaffresidsDirs[@]} # This gives us back a list
-else
-  highaffresidsFileList=$highaffresidsFile
+elif [[ $hotspotsFile = "all" ]]; then
+  hotspotsFile=`du -d 2 | awk '{ print $2 }' | head -n -2`
+elif [[ $hotspotsFile = "best" ]]; then
+  hotspotsFile='highaffresid/best-site'
 fi
 
-echo "highaffresidsFileList is set to contain"
-for file in $highaffresidsFileList; do
-  echo $file
-done
-
-if [[ ${#highaffresidsDirs[@]} -eq 0 ]]; then
-  highaffresidsDirs+=$(dirname "$highaffresidsFile")
-  num_haf_dirs=1
-else
-  num_haf_dirs=${#highaffresidsDirs[@]}
+if [[ $hotspotsFile = '' ]]; then
+  echo "Please provide a path to hot spots file or a site directory to find it in"
+  echo ""
+  exit
 fi
 
-echo "the array contains $num_haf_dirs directories"
-echo ""
-
-highaffresidsFiles=()
-for file in $highaffresidsFile; do
-  if [[ -d $file ]]; then
-    highaffresidsFiles+=(`ls $file/*highaffresid.dat`)
-  else
-    highaffresidsFiles+=($file)
-  fi
-done
-highaffresidsFileList=${highaffresidsFiles[@]} # This gives us back a list
-
-echo "highaffresidsFileList is set to contain"
-for file in $highaffresidsFileList; do
-  echo $file
-done
-echo ""
-
-# Set hotspotsFile to point to actual files (after passing on the directories)
-
+noPDBs=1
+IFS=','
+numHotspotsEntries=0
 hotspotsFiles=()
 for file in $hotspotsFile; do
   if [[ -d $file ]]; then
-    hotspotsFiles+=(`ls $file/*site_?_soln_?.pdb`)
+    IFS=$' \t\n'
+    hotspotsFilesList=`ls $file*pdb`
+    for file2 in $hotspotsFilesList; do
+      noPDBs=0
+      hotspotsFiles+=($file2)
+      ((numHotspotsEntries++))
+    done
   else
-    hotspotsFiles+=($file)
+    if [[ $file == *pdb ]]; then
+      noPDBs=0
+      hotspotsFiles+=($file)
+      ((numHotspotsEntries++))
+    fi
   fi
 done
 hotspotsFileList=${hotspotsFiles[@]} # This gives us back a list
 
-echo "hotspotsFileList is set to contain"
+if [[ ${#hotspotsFileList[@]} -eq 0 ]]; then 
+  echo "Please provide a path to hot spots file or a valid site directory to find it in"
+  echo ""
+  exit
+fi
+
+if [[ $noPDBs -eq 1 ]]; then
+  echo "Hot spots files should end in .pdb"
+  echo ""
+  exit
+fi
+
+# Tell the user what the hot spots file is
+
+IFS=$' \t\n'
+echo "hotspotsFile is set to contain"
 for file in $hotspotsFileList; do
   echo $file
 done
-num_hs_files=${#hotspotsFiles[@]}
-echo "the array contains $num_hs_files filenames"
+echo ""
+#############################################################
+
+# Report CL value
+
+echo "CL is set to $CL"
 echo ""
 
-#if [[ $num_hs_files != $num_haf_dirs ]]; then
-#  echo "ERROR: the numbers of hotspot files ($num_hs_files) and highaffresid directories ($num_haf_dirs) do not match"
-#  echo ""
-#  exit
-#fi
+# Sort out highaffresids files
+#############################################################
+selectedBest=0
+if [[ $highaffresidsFile = "site-list.dat" ]]; then
+  if [[ $siteListExists -eq 1 ]]; then
+    highaffresidsFile=`cat $highaffresidsFile`
+  else
+    highaffresidsFile='highaffresid'
+  fi
+elif [[ $highaffresidsFile = "all" ]]; then
+  highaffresidsFile=`du -d 2 | awk '{ print $2 }' | head -n -2`
+elif [[ $highaffresidsFile = "best" ]]; then
+  highaffresidsFile='highaffresid/best-site'
+  selectedBest=1
+fi
+
+echo "highaffresidsFile is set to contain"
+for file in $highaffresidsFile; do
+  echo $file
+done
+echo ""
+
+numHighaffresidDirs=0
+highaffresidsFiles=()
+for file in $highaffresidsFile; do
+  if [[ -d $file ]]; then
+    highaffresidsFiles+=(`ls $file/*highaffresid.dat`)
+    ((numHighaffresidDirs++))
+  else
+    highaffresidsFiles+=($file)
+  fi
+done
+highaffresidsFileList=${highaffresidsFiles[@]} # This gives us back a lists
+
+if [[ $numHighaffresidDirs -eq 0 ]]; then
+  highaffresidsDirs='highaffresid'
+else
+  highaffresidsDirs=$highaffresidsFile
+fi
+
+# Make sure it gives us highaffresid.dat files
+
+for file in $highaffresidsFileList; do
+  if [[ $file != *highaffresid.dat ]]; then
+    echo "All highaffresid files should end in highaffresid.dat"
+    echo ""
+    exit
+  fi
+done
+
+echo "highaffresidsFileList is set to contain"
+for file in $highaffresidsFileList; do
+  echo $file
+done
+echo ""
+#############################################################
 
 # Set proteinFile, CHAIN and PROBE
 
-if [[ proteinFile != "*pdb" ]]; then
+if [[ $proteinFile != "*pdb" ]]; then
   proteinFile=`cat $proteinFile` || proteinFile=$proteinFile
 fi
 
@@ -174,81 +192,104 @@ for file in $proteinFile; do
 done
 echo ""
 
-CHAIN=`cat $CHAIN` || CHAIN=$CHAIN
+if [[ -f $CHAIN ]]; then
+  CHAIN=`cat $CHAIN` 
+else
+  IFS=','
+  for chain in $CHAIN; do
+    chains+=($chain)
+  done
+  CHAIN=${chains[@]}
+fi
+IFS=$' \t\n'
+
 echo "CHAIN is set to contain"
 for CC in $CHAIN; do
   echo $CC
 done
 echo ""
 
-PROBE=`cat $PROBE` || PROBE=$PROBE
+if [[ -f $PROBE ]]; then
+  PROBE=`cat $PROBE` 
+else
+  IFS=','
+  for probe in $PROBE; do
+    probes+=($probe)
+  done
+  PROBE=${probes[@]}
+fi
+IFS=$' \t\n'
+
 echo "PROBE is set to contain"
 for probe in $PROBE; do
   echo $probe
 done
 echo ""
 
-# report about setting dir
 
-if [ -z ${dir+x} ]; then 
-  echo "dir is unset and will be set in the loop"
-else 
-  echo "dir is set to '$dir'"
-fi
+echo "There are $numHotspotsEntries hot spots file entries"
+echo "There are $numHighaffresidDirs highaffresid file directories"
+echo ""
 
+# Start actual calculations
 
-for i in `seq 0 $(expr $num_haf_dirs - 1)`; do
-
-
-  if [ -z ${dir+x} ]; then
-    dir=${highaffresidsDirs[${i}]}
-  fi
-  
-  j=0
-  for hotspotsFile in $hotspotsFileList; do
-    ((j++))
-    if [ "$j" -gt "$i" ]; then
-      break
+for i in `seq 0 $(expr $numHighaffresidDirs - 1)`; do
+  arr=($highaffresidsDirs)
+  dir=(${arr[${i}]})
+  if [[ $dir = *best-site ]]; then
+    if [[ $selectedBest -eq 0 ]]; then
+      ((i++))
+      continue
     fi
-  done
+  fi
 
-  for CC in $CHAIN; do
-    for probe in $PROBE; do
+  for hotspotsFile in $hotspotsFileList; do
 
-      echo ""
-      echo "iteration $i, directory $dir, chain $CC, probe $probe"
+    suffix=`echo $hotspotsFile | awk -F/ '{ print $NF }' | awk -F. '{ print $1 }'`
+    echo $suffix >> site-list2.dat
+    dir2="highaffresid/$suffix"
+    mkdir -p $dir2
 
-      for file in $highaffresidsFileList; do
-        highaffresidsfile=`echo $file | grep $dir | grep $probe | grep "/$CC"`
-        if [ ! -z "$highaffresidsfile" ]; then
-          highaffresids=`head $highaffresidsfile`
-          if [ ! -z "$highaffresids" ]; then
-            echo $highaffresids
+    for CC in $CHAIN; do
+      for probe in $PROBE; do
 
-            echo "running command: hotspotsnearhighaffresids.sh $CC $probe $CL $highaffresidsfile $proteinFile $hotspotsFile $dir"
-            hotspotsnearhighaffresids.sh $CC $probe $CL $highaffresidsfile $proteinFile $hotspotsFile $dir
-            
-            if [[ -f $dir/$probe-$CC/$probe-$CC-all2-highaffresid.dat ]]; then
-              cat $dir/$probe-$CC/$probe-$CC-all2-highaffresid.dat >> $dir/highaffresid2.dat
+        for file in $highaffresidsFileList; do
+          highaffresidsfile=`echo $file | grep $dir | grep $probe | grep "/$CC"`
+          if [ ! -z "$highaffresidsfile" ]; then
+            highaffresids=`head $highaffresidsfile`
+            if [ ! -z "$highaffresids" ]; then
+              echo $highaffresids
+
+              echo "running command: hotspotsnearhighaffresids.sh $CC $probe $CL $highaffresidsfile $proteinFile $hotspotsFile $dir2"
+              hotspotsnearhighaffresids.sh $CC $probe $CL $highaffresidsfile $proteinFile $hotspotsFile $dir2
+              
+              if [[ -f $dir2/$probe-$CC/$probe-$CC-all2-highaffresid.dat ]]; then
+                cat $dir2/$probe-$CC/$probe-$CC-all2-highaffresid.dat >> $dir2/highaffresid2.dat
+              fi
+
+              if [[ -f $dir2/$probe-$CC/$probe-$CC-all-hs.pdb ]]; then
+                cat $dir2/$probe-$CC/$probe-$CC-all-hs.pdb >> $dir2/hotspots.pdb
+              fi
+
+              rm -rf $dir2/$probe-$CC/
+
+            else
+              echo "No high affinity residues for this condition"
             fi
-
-            if [[ -f $dir/$probe-$CC/$probe-$CC-all-hs.pdb ]]; then
-              cat $dir/$probe-$CC/$probe-$CC-all-hs.pdb >> hotspots.pdb
-            fi
-
-            rm -rf $dir/$probe-$CC/
-
-          else
-            echo "No high affinity residues for this condition"
           fi
-        fi
-      done # end loop for highaffresid files
-    done # end loop for probes
-  done # end loop for chains
-done # end loop for directories
+        done # end loop for highaffresid files
+      done # end loop for probes
+    done # end loop for chains
 
-sort --unique hotspots.pdb > $dir/hotspots2.pdb
-rm hotspots.pdb
+    if [[ -f $dir2/hotspots.pdb ]]; then
+      sort --unique $dir2/hotspots.pdb > $dir2/hotspots2.pdb
+      sort --unique $dir2/hotspots.pdb > $dir/all-hotspots2.pdb
+      rm $dir2/hotspots.pdb
+    fi
+
+  done # end loop for hotspots files
+
+done # end loop for directories
 
 echo ""
 

--- a/snapshotselection.sh
+++ b/snapshotselection.sh
@@ -4,7 +4,7 @@
 # Druggability molecular dynamics simulations
 
 ######### Check here  #######
-CUTOFF3=1000
+CUTOFF3=''
 # input directory
 INDIR='site-list2.dat'
 # PDB file name and path
@@ -17,12 +17,18 @@ frameFirst='first'
 frameLast='last'
 ######### Check here  #######
 
+if [[ $# -lt 1 ]]; then
+  echo "Please provide a frequency score cutoff"
+  echo ""
+  exit
+fi
+
 for arg in `seq 1 "$#"`; do
   if [[ "$arg" -eq 1 ]]; then
     CUTOFF3=$1
   elif [[ "$arg" -eq 2 ]]; then
     INDIR=$2
-  if [[ "$arg" -eq 3 ]]; then
+  elif [[ "$arg" -eq 3 ]]; then
     PDB=$3
   elif [[ "$arg" -eq 4 ]]; then
     DCD=$4
@@ -60,7 +66,7 @@ if [[ $1 = "help" ]]; then
   exit
 fi
 
-# Set DCD, PDB, CHAIN and PROBE
+# Set DCD, PDB, INDIR, CHAIN and PROBE
 if [[ DCD != "*dcd" ]]; then
   DCD=`cat $DCD` || DCD=$DCD
 fi
@@ -69,9 +75,13 @@ if [[ PDB != "*pdb" ]]; then
   PDB=`cat $PDB` || DCD=$DCD
 fi
 
+if [[ -f $INDIR ]]; then
+  INDIR=`cat $INDIR`
+fi
+
 IFS=','
 INDIRS=()
-for $indir in $INDIR; do
+for indir in $INDIR; do
   INDIRS+=($indir)
 done
 INDIR=${INDIRS[@]}
@@ -83,7 +93,7 @@ do
   FOUTDIR="snapshot/`echo $FINDIR | awk -F/ '{print $NF}'`"
 
   #########
-  awk '{if ($1 >= "'"$CUTOFF3"'") print }' $FOUTDIR/zlist-count  > ___test 
+  awk -v cutoff=$CUTOFF3 '{if ($1 >= cutoff ) print }' $FOUTDIR/zlist-count > ___test 
 
   mkdir CUT$CUTOFF3
 
@@ -99,11 +109,11 @@ do
 
   ######### zlist-frame-c1000 zlist-frame-c1000-detail
   if [[ "$frameFirst" -eq "first" ]]; then
-    frameFirst=1
+    frameFirst=0
   fi
 
   if [[ "$frameLast" -eq "last" ]]; then
-    frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
+    frameLast=`tail -n1 $FOUTDIR/*/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
   fi
 
   KK=1
@@ -170,3 +180,4 @@ do
   # Extract protein and ligand ##
 
 done
+exit

--- a/snapshotselection.sh
+++ b/snapshotselection.sh
@@ -106,7 +106,7 @@ do
     frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
   fi
 
-  KK=0
+  KK=1
   for traj in $DCD
   do
     for (( nn = $frameFirst ; nn <= $frameLast   ; nn++ ))

--- a/snapshotselection.sh
+++ b/snapshotselection.sh
@@ -83,7 +83,7 @@ do
   FOUTDIR="snapshot/`echo $FINDIR | awk -F/ '{print $NF}'`"
 
   #########
-  awk '{if (\$1 >= "'"$CUTOFF3"'") print }' $FOUTDIR/zlist-count  > ___test 
+  awk '{if ($1 >= "'"$CUTOFF3"'") print }' $FOUTDIR/zlist-count  > ___test 
 
   mkdir CUT$CUTOFF3
 

--- a/snapshotselection.sh
+++ b/snapshotselection.sh
@@ -4,80 +4,58 @@
 # Druggability molecular dynamics simulations
 
 ######### Check here  #######
+CUTOFF3=1000
+# input directory
+INDIR='site-list2.dat'
 # PDB file name and path
 PDB='struc-list.dat'
-# DCD file name and path RRR is variable
+# DCD file name and path
 DCD='traj-list.dat'
-# DCD trajectory number for RRR
-TRJNUM=' 1 '
-# frame number for each dcd         
-FRANUM=10000
-# protein chain ID in pdb
-#CHAIN='chain-list.dat'
-# probe molecule ID in pdb
-#PROBE='probe-list.dat' 
-# cutoff between residue and probe      
-#CUTOFF=4.0
-# cutoff between probe and hot spot
-#CUTOFF2=1.5
-# frequency of dcd for analysis
-STEP=1
-# output directory             
-OUTDIR=' s1 '
-# cutoff of score for collecting snapshots
-CUTOFF3=1000
+# first frame number for each dcd 
+frameFirst='first'
+# last frame number for each dcd        
+frameLast='last'
 ######### Check here  #######
 
 for arg in `seq 1 "$#"`; do
   if [[ "$arg" -eq 1 ]]; then
-    PDB=$1
+    CUTOFF3=$1
   elif [[ "$arg" -eq 2 ]]; then
-    DCD=$2
-  #elif [[ "$arg" -eq 3 ]]; then
-  #  TRJNUM=$3
-  #elif [[ "$arg" -eq 4 ]]; then
-  #  FRANUM=$4
-  elif [[ "$arg" -eq 3 ]]; then
-    CHAIN=$4
+    INDIR=$2
+  if [[ "$arg" -eq 3 ]]; then
+    PDB=$3
   elif [[ "$arg" -eq 4 ]]; then
-    PROBE=$4
-  #elif [[ "$arg" -eq 7 ]]; then
-  #  CUTOFF=$7
-  #elif [[ "$arg" -eq 8 ]]; then
-  #  CUTOFF2=$8
+    DCD=$4
   elif [[ "$arg" -eq 5 ]]; then
-    STEP=$5
+    CHAIN=$5
   elif [[ "$arg" -eq 6 ]]; then
-    OUTDIR=$6
+    PROBE=$6
   elif [[ "$arg" -eq 7 ]]; then
-    CUTOFF3=$7
+    frameFirst=$7
+  elif [[ "$arg" -eq 8 ]]; then
+    frameLast=$8
   fi
 done
 
 if [[ $1 = "help" ]]; then
-  echo "This script takes up to 7 arguments in the following order"
+  echo "This script takes up to 8 arguments in the following order"
+  echo ""
+  echo "cutoff of frequency score for collecting snapshots, "
+  echo ""
+  echo "input directory for results from site selection step "
+  echo "This is used to locate the results from the snapshot statistics step"
   echo ""
   echo "protein PDB file path, "
   echo ""
   echo "protein DCD file path, "
   echo ""
-  #echo "trajectory numbers for multiple runs, "
-  #echo ""
-  #echo "number of frames to use, "
-  #echo ""
-  #echo "chain ID, "
-  #echo ""
-  #echo "probe type, "
-  #echo ""
-  #echo "cutoff between residue and probe, "
-  #echo ""
-  #echo "cutoff between probe and hot spot, "
-  #echo ""
-  echo "step for reading the trajectories, "
+  echo "chain ID, "
   echo ""
-  echo "output directory for results, "
+  echo "probe type, "
   echo ""
-  echo "cutoff of score for collecting snapshots, "
+  echo "first frame to use, "
+  echo ""
+  echo "last frame to use, "
   echo ""
   exit
 fi
@@ -91,94 +69,104 @@ if [[ PDB != "*pdb" ]]; then
   PDB=`cat $PDB` || DCD=$DCD
 fi
 
-for FOUTDIR in $OUTDIR
-do
-
-#########
-cat > _molexe  <<EOF
-awk '{if (\$1 >= $CUTOFF3) print }' snapshot-$FOUTDIR/zlist-count  > ___test 
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
-
-mkdir CUT$CUTOFF3
-
-TNUM=`wc -l ___test | awk '{print $1}'`
-for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
-do
-sed -n -e "$mm,$mm p" ___test > ___test2
-sed -e "s/outfr.dat/  /g" ___test2 > ___test3
-
-FF=`cat ___test3 | awk '{print $2}'`
-cp -r $FF CUT$CUTOFF3
+IFS=','
+INDIRS=()
+for $indir in $INDIR; do
+  INDIRS+=($indir)
 done
+INDIR=${INDIRS[@]}
+IFS=$' \t\n'
 
-rm ___t*
-############
-
-######### zlist-frame-c1000 zlist-frame-c1000-detail
-for KK in $TRJNUM
-do
-for (( nn = 0   ; nn <= $FRANUM   ; nn++ ))
+for FINDIR in $INDIR
 do
 
-grep "SIM# $KK FRAME# $nn "  CUT$CUTOFF3/z.*/outfr.dat > ___test
+  FOUTDIR="snapshot/`echo $FINDIR | awk -F/ '{print $NF}'`"
 
-CRAT=`wc -l ___test | awk '{print $1}'`
+  #########
+  awk '{if (\$1 >= "'"$CUTOFF3"'") print }' $FOUTDIR/zlist-count  > ___test 
 
-if [ $CRAT -eq $TNUM ]; then
-cat   ___test >> ___test2
-echo "SIM# $KK FRAME# $nn   $CRAT"  >> ___test3
-fi
+  mkdir CUT$CUTOFF3
 
-done
-done
+  TNUM=`wc -l ___test | awk '{print $1}'`
+  for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
+  do
+    FF=`sed -n -e "$mm,$mm p" ___test | sed -e "s/outfr.dat/  /g" | awk '{print $2}'`
+    cp -r $FF CUT$CUTOFF3
+  done
 
-cp ___test2    snapshot-$FOUTDIR/zlist-frame-c$CUTOFF3-detail
-cp ___test3    snapshot-$FOUTDIR/zlist-frame-c$CUTOFF3
+  rm ___t*
+  ############
 
-rm  __*
-\rm -r CUT$CUTOFF3
-######### zlist-frame-c1000 zlist-frame-c1000-detail
+  ######### zlist-frame-c1000 zlist-frame-c1000-detail
+  if [[ "$frameFirst" -eq "first" ]]; then
+    frameFirst=1
+  fi
+
+  if [[ "$frameLast" -eq "last" ]]; then
+    frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
+  fi
+
+  KK=0
+  for traj in $DCD
+  do
+    for (( nn = $frameFirst ; nn <= $frameLast   ; nn++ ))
+    do
+
+      grep "SIM# $KK FRAME# $nn "  CUT$CUTOFF3/z.*/outfr.dat > ___test
+
+      CRAT=`wc -l ___test | awk '{print $1}'`
+
+      if [ $CRAT -eq $TNUM ]; then
+        cat   ___test >> $FOUTDIR/zlist-frame-c$CUTOFF3-detail
+        echo "SIM# $KK FRAME# $nn   $CRAT"  >> $FOUTDIR/zlist-frame-c$CUTOFF3
+      fi
+
+    done
+    ((KK++))
+  done
+
+  rm  __*
+  \rm -r CUT$CUTOFF3
+  ######### zlist-frame-c1000 zlist-frame-c1000-detail
 
 
-# Extract protein and ligand ##
+  # Extract protein and ligand ##
 
-SNAPSNUM=`wc -l snapshot-$FOUTDIR/zlist-frame-c$CUTOFF3 | awk '{print $1}'`
+  SNAPSNUM=`wc -l $FOUTDIR/zlist-frame-c$CUTOFF3 | awk '{print $1}'`
 
-for (( yy = 1 ; yy <= $SNAPSNUM  ; yy++ ))
-do
+  for (( yy = 1 ; yy <= $SNAPSNUM  ; yy++ ))
+  do
 
-sed -n -e "$yy,$yy p" snapshot-$FOUTDIR/zlist-frame-c$CUTOFF3  > _____tt
-FF=`cat _____tt | awk '{print $2}'`
-FFRAM=`cat _____tt | awk '{print $4}'`
-grep "$FF FRAME# $FFRAM" snapshot-$FOUTDIR/zlist-frame-c$CUTOFF3-detail > _____tt2
+    sed -n -e "$yy,$yy p" $FOUTDIR/zlist-frame-c$CUTOFF3  > _____tt
+    FF=`cat _____tt | awk '{print $2}'`
+    FFRAM=`cat _____tt | awk '{print $4}'`
+    grep "$FF FRAME# $FFRAM" $FOUTDIR/zlist-frame-c$CUTOFF3-detail > _____tt2
 
-TTTTNUM=`wc -l _____tt2 | awk '{print $1}'`
+    TTTTNUM=`wc -l _____tt2 | awk '{print $1}'`
 
-if [ $TTTTNUM -ge 1 ]; then
-for (( bb = 1 ; bb <= $TTTTNUM  ; bb++ ))
-do
-sed -n -e  "$bb,$bb p" _____tt2 > _____tt3
+    if [ $TTTTNUM -ge 1 ]; then
+      for (( bb = 1 ; bb <= $TTTTNUM  ; bb++ ))
+      do
+        sed -n -e  "$bb,$bb p" _____tt2 > _____tt3
 
-PPROB=`cat _____tt3 | awk '{print $6}'`
-PPRON=`cat _____tt3 | awk '{print $8}'`
-env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot3.tcl -args $PDB $DCD $STEP $FFRAM $PPROB $PPRON $FF
+        PPROB=`cat _____tt3 | awk '{print $6}'`
+        PPRON=`cat _____tt3 | awk '{print $8}'`
+        env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot3.tcl -args $PDB $DCD $FFRAM $PPROB $PPRON $FF
 
-mkdir snapshot-$FOUTDIR/zpdb-frame-c$CUTOFF3
-mv  pro*.pdb snapshot-$FOUTDIR/zpdb-frame-c$CUTOFF3
-mv  lig*.pdb snapshot-$FOUTDIR/zpdb-frame-c$CUTOFF3
+        mkdir -p $FOUTDIR/zpdb-frame-c$CUTOFF3
+        mv  pro*.pdb $FOUTDIR/zpdb-frame-c$CUTOFF3
+        mv  lig*.pdb $FOUTDIR/zpdb-frame-c$CUTOFF3
 
-done
-fi
+      done
+    fi
 
-cat snapshot-$FOUTDIR/zpdb-frame-c$CUTOFF3/lig-$FF-$FFRAM-*.pdb > ____xx
-grep -v 'END'    ____xx   > ____xx2
-grep -v 'CRYST1' ____xx2  > snapshot-$FOUTDIR/zpdb-frame-c$CUTOFF3/lig-$FF-$FFRAM.pdb
+    cat $FOUTDIR/zpdb-frame-c$CUTOFF3/lig-$FF-$FFRAM-*.pdb > ____xx
+    grep -v 'END'    ____xx   > ____xx2
+    grep -v 'CRYST1' ____xx2  > $FOUTDIR/zpdb-frame-c$CUTOFF3/lig-$FF-$FFRAM.pdb
+    rm $FOUTDIR/zpdb-frame-c$CUTOFF3/lig-$FF-$FFRAM-*.pdb 
 
-done
-rm -r __*
-# Extract protein and ligand ##
+  done
+  rm -r __*
+  # Extract protein and ligand ##
 
 done

--- a/snapshotstatistics.sh
+++ b/snapshotstatistics.sh
@@ -5,78 +5,69 @@
 # and rank dominant interactions
 
 ######### Check here  #######
-# PDB file name and path
-PDB='struc-list.dat'
-# DCD file name and path RRR is variable
-DCD='traj-list.dat'
-# DCD trajectory number for RRR
-TRJNUM=' 1 '
-# frame number for each dcd         
-FRANUM=10000
-# protein chain ID in pdb
-CHAIN='chain-list.dat'
-# probe molecule ID in pdb
-PROBE='probe-list.dat' 
+# input directory
+INDIR='site-list2.dat'
 # cutoff between residue and probe      
 CUTOFF=4.0
 # cutoff between probe and hot spot
 CUTOFF2=1.5
-# frequency of dcd for analysis
-STEP=1
-# input directory
-INDIR='highaffresid'
-# output directory             
-OUTDIR=' s1 '
+# PDB file name and path
+PDB='struc-list.dat'
+# DCD file name and path
+DCD='traj-list.dat'
+# protein chain ID in pdb
+CHAIN='chain-list.dat'
+# probe molecule ID in pdb
+PROBE='probe-list.dat' 
+# first frame number for each dcd 
+frameFirst='first'
+# last frame number for each dcd        
+frameLast='last'
 ######### Check here  #######
 
-for arg in `seq 1 "$#"`; do
+for arg in `seq 1 "$#"`; 
   if [[ "$arg" -eq 1 ]]; then
-    PDB=$1
+    INDIR=$1
   elif [[ "$arg" -eq 2 ]]; then
-    DCD=$2
+    CUTOFF=$2
   elif [[ "$arg" -eq 3 ]]; then
-    TRJNUM=$3
+    CUTOFF2=$3
   elif [[ "$arg" -eq 4 ]]; then
-    FRANUM=$4
+    PDB=$4
   elif [[ "$arg" -eq 5 ]]; then
-    CHAIN=$5
-  elif [[ "$arg" -eq 6 ]]; then
-    PROBE=$6
+    DCD=$5
   elif [[ "$arg" -eq 7 ]]; then
-    CUTOFF=$7
+    CHAIN=$7
   elif [[ "$arg" -eq 8 ]]; then
-    CUTOFF2=$8
+    PROBE=$8
   elif [[ "$arg" -eq 9 ]]; then
-    STEP=$9
+    frameFirst=$9
   elif [[ "$arg" -eq 10 ]]; then
-    INDIR=${10}
-  elif [[ "$arg" -eq 11 ]]; then
-    OUTDIR=${11}
+    frameLast=${10}
   fi
 done
 
 if [[ $1 = "help" ]]; then
-  echo "This script takes up to 7 arguments in the following order"
+  echo "This script takes up to 10 arguments in the following order"
   echo ""
-  echo "protein PDB file path, "
-  echo ""
-  echo "protein DCD file path, "
-  echo ""
-  echo "trajectory numbers for multiple runs, "
-  echo ""
-  echo "number of frames to use, "
-  echo ""
-  echo "chain ID, "
-  echo ""
-  echo "probe type, "
+  echo "input directory for results from site selection step"
+  echo "The last part of this is used as a suffix for creating a new directory"
   echo ""
   echo "cutoff between residue and probe, "
   echo ""
   echo "cutoff between probe and hot spot, "
   echo ""
-  echo "step for reading the trajectories, "
+  echo "protein PDB file path, "
   echo ""
-  echo "output directory for results, "
+  echo "protein DCD file path, "
+  echo ""
+  echo "chain ID, "
+  echo ""
+  echo "probe type, "
+  echo ""
+  echo "first frame to use, "
+  echo ""
+  echo "last frame to use, "
   echo ""
   exit
 fi
@@ -88,7 +79,7 @@ fi
 DCD=`echo $DCD | sed 's/ /,/'`
 
 if [[ PDB != "*pdb" ]]; then
-  PDB=`cat $PDB` || DCD=$DCD
+  PDB=`cat $PDB` || PDB=$PDB
 fi
 PDB=`echo $PDB | sed 's/ /,/'`
 
@@ -96,192 +87,170 @@ CHAIN=`cat $CHAIN` || CHAIN=$CHAIN
 
 PROBE=`cat $PROBE` || PROBE=$PROBE
 
-for FOUTDIR in $OUTDIR
-do
-
-mkdir -p snapshot-$FOUTDIR
-
-for FCHAIN in $CHAIN
-do
-for FPROBE in $PROBE
-do
-
-grep "$FPROBE $FCHAIN" $INDIR/highaffresid2.dat > ____tt
-sed -e "s/$FPROBE $FCHAIN/    /g" ____tt > ____tt1
-RESID=`cat ____tt1 | awk '{print $0}'`
-
-# Check Current EE 154 = Tyr151
-for EE in $RESID
-do
-resdir=z.$FCHAIN.$EE.$FPROBE
-mkdir $resdir
-
-# Check Current FF ############
-mkdir __run
-for FF in $TRJNUM
-do
-cd __run
-env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot1.tcl -args ../$PDB ../$DCD $STEP $CUTOFF $FPROBE $EE $FCHAIN $FF
-cd ..
-done
-
-mv  __run/ligbo*  $resdir
-cat __run/v*pdb > $resdir/v-com.pdb
-ls  __run/v*pdb >  __test
-awk '{print $1, (NR-1) }' __test > $resdir/zlist
-
-rm -r __run
-###############################
-
-grep $FPROBE $INDIR/hotspots2.pdb > _____test0
-sort -n -k10 _____test0             > __test1
-
-TNUM=`wc -l __test1 | awk '{print $1}'`
-
-echo "/END/{i\\" > __test3
-
-for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
-do
-sed -n -e "$mm,$mm p" __test1 > __test2
-
-cat > ___molexe  <<EOF
-awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "$mm", "C2", "$FPROBE", "M", "$mm", \$6, \$7, \$8, \$9, \$10, "M\\\" )}' \
-__test2 >> __test3
-awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "$mm", "C2", "$FPROBE", "M", "$mm", \$6, \$7, \$8, \$9, \$10, "M" )}' \
-__test2 >> __ttest3
-EOF
-chmod 777 ___molexe
-./___molexe
-rm ___molexe
-done
-
-cp __ttest3 $resdir/hot-spot.pdb
-
-echo "END " >> __test3
-echo "d "   >> __test3
-echo "} "   >> __test3
-
-sed -f __test3  $resdir/v-com.pdb > $resdir/v-com-ok.pdb
-rm _*
-
-#########
-for (( FF = 1 ; FF <= $TNUM  ; FF++ ))
-do
-cd $resdir
-#mkdir $kesdir
-env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot2.tcl -args $STEP $CUTOFF2 $FPROBE $FF
-#mv ligbo-ok.dat xok*pdb    $kesdir
-mv _ligbo-ok.dat ligbo-ok.$FF.dat
-
-TNNN=`wc -l zlist | awk '{print $1}'`
-
-for (( rr = 0   ; rr <= $TNNN     ; rr++ ))
-do
-
-cat > _molexe  <<EOF
-awk '{if (\$1 == $rr) print }' ligbo-ok.$FF.dat > ___test2
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
-
-CRAT=`wc -l ___test2 | awk '{print $1}'`
-
-if [ $CRAT -ge 1 ]; then
-cat > _molexe  <<EOF
-awk '{if (\$2 == $rr) print }' zlist  > ___test3
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
-
-perl -i -pe 's/-/ /g' ___test3
-perl -i -pe 's/.pdb/    /g' ___test3
-
-FRAMT=`cat ___test3 | awk '{print $2}'`
-FRAME=`cat ___test3 | awk '{print $3}'`
-FRAMM=`cat ___test3 | awk '{print $4}'`
-
-cat > _molexe  <<EOF
-awk '{if (\$1 == $FRAMM) print $FRAMT , $FRAME , \$3, \$4, \$5, \$7, \$8, \$10 }' ligbo-ok.$FF.dat >> tout-hotspot-$FF.dat
-awk '{if (\$1 == $FRAME) print $FRAMT , \$0 }' ligbo-$FRAMT.dat        >> tout-res-$FF.dat
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
-
-awk '{print "SIM#", $2, "FRAME#", $3 }' ___test3 >> tout-$FF.dat
-#cat xok-$rr.pdb  >> x-com.$FF.pdb
+if [[ -f $INDIR ]]; then
+  INDIR=`cat $INDIR`
 fi
 
+IFS=','
+INDIRS=()
+for $indir in $INDIR; do
+  INDIRS+=($indir)
 done
+INDIR=${INDIRS[@]}
+IFS=$' \t\n'
 
-rm _*
-cd ..
-
-#### Sort
-for KK in $TRJNUM
+for FINDIR in $INDIR
 do
-cat > _molexe  <<EOF
-awk '{if (\$2 == $KK) print }' $resdir/tout-$FF.dat         > ______test1
-awk '{if (\$1 == $KK) print }' $resdir/tout-res-$FF.dat     > ______test2
-awk '{if (\$1 == $KK) print }' $resdir/tout-hotspot-$FF.dat > ______test3
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
 
-sort -n -k4 ______test1 >>  $resdir/out-$FF.dat         
-sort -n -k2 ______test2 >>  $resdir/out-res-$FF.dat     
-sort -n -k2 ______test3 >>  $resdir/out-hotspot-$FF.dat 
+  FOUTDIR="snapshot/`echo $FINDIR | awk -F/ '{print $NF}'`"
+  mkdir -p $FOUTDIR
+
+  for FCHAIN in $CHAIN
+  do
+    for FPROBE in $PROBE
+    do
+
+    grep "$FPROBE $FCHAIN" $INDIR/highaffresid2.dat > ____tt
+    sed -e "s/$FPROBE $FCHAIN/    /g" ____tt > ____tt1
+    RESID=`cat ____tt1 | awk '{print $0}'`
+
+    for EE in $RESID
+    do
+      resdir=z.$FCHAIN.$EE.$FPROBE
+      mkdir $resdir
+
+      mkdir __run
+      cd __run
+      env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot1.tcl -args ../$PDB ../$DCD $CUTOFF $FPROBE $EE $FCHAIN
+    done
+
+    mv  __run/ligbo*  $resdir
+    cat __run/v*pdb > $resdir/v-com.pdb
+    ls  __run/v*pdb >  __test
+    awk '{print $1, (NR-1) }' __test > $resdir/zlist
+
+    rm -r __run
+    ###############################
+
+    grep $FPROBE $INDIR/hotspots2.pdb | sort -n -k10 > __test1
+
+    TNUM=`wc -l __test1 | awk '{print $1}'`
+
+    echo "/END/{i\\" > __test3
+
+    for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
+    do
+      sed -n -e "$mm,$mm p" __test1 > __test2
+
+      awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", \$6, \$7, \$8, \$9, \$10, "M\\\" )}' \
+      __test2 >> __test3
+      awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", \$6, \$7, \$8, \$9, \$10, "M" )}' \
+      __test2 >> __ttest3
+
+    done
+
+    cp __ttest3 $resdir/hot-spot.pdb
+
+    echo "END " >> __test3
+    echo "d "   >> __test3
+    echo "} "   >> __test3
+
+    sed -f __test3  $resdir/v-com.pdb > $resdir/v-com-ok.pdb
+    rm _*
+
+    #########
+    for (( FF = 1 ; FF <= $TNUM  ; FF++ ))
+    do
+      cd $resdir
+
+      env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot2.tcl -args $CUTOFF2 $FPROBE $FF
+
+      mv _ligbo-ok.dat ligbo-ok.$FF.dat
+
+      TNNN=`wc -l zlist | awk '{print $1}'`
+
+      for (( rr = 0   ; rr <= $TNNN     ; rr++ ))
+      do
+
+        awk '{if (\$1 == "'"$rr"'") print }' ligbo-ok.$FF.dat > ___test2
+
+        CRAT=`wc -l ___test2 | awk '{print $1}'`
+
+        if [ $CRAT -ge 1 ]; then
+          awk '{if (\$2 == "'"$rr"'") print }' zlist  > ___test3
+
+          perl -i -pe 's/-/ /g' ___test3
+          perl -i -pe 's/.pdb/    /g' ___test3
+
+          FRAMT=`cat ___test3 | awk '{print $2}'`
+          FRAME=`cat ___test3 | awk '{print $3}'`
+          FRAMM=`cat ___test3 | awk '{print $4}'`
+
+          awk '{if (\$1 == "'"$FRAMM"'") print "'"$FRAMT"'" , "'"$FRAME"'" , \$3, \$4, \$5, \$7, \$8, \$10 }' ligbo-ok.$FF.dat >> tout-hotspot-$FF.dat
+          awk '{if (\$1 == "'"$FRAME"'") print "'"$FRAMT"'" , \$0 }' ligbo-$FRAMT.dat        >> tout-res-$FF.dat
+
+          awk '{print "SIM#", $2, "FRAME#", $3 }' ___test3 >> tout-$FF.dat
+        fi
+
+      done
+
+      rm _*
+      cd ..
+
+      #### Sort
+      KK=0
+      for traj in $DCD; do
+        awk '{if (\$2 == "'"$KK"'") print }' $resdir/tout-$FF.dat | sort -n -k4 >> $resdir/out-$FF.dat
+        awk '{if (\$1 == "'"$KK"'") print }' $resdir/tout-res-$FF.dat | sort -n -k2 >> $resdir/out-res-$FF.dat
+        awk '{if (\$1 == "'"$KK"'") print }' $resdir/tout-hotspot-$FF.dat | sort -n -k2 >> $resdir/out-hotspot-$FF.dat 
+        ((KK++))
+      done
+      #### Sort
+
+      wc -l $resdir/out-$FF.dat  >> $resdir/out-count
+      cat $resdir/out-$FF.dat  >> ___tttt            
+
+    done
+
+    #########
+
+    rm    $resdir/v*pdb $resdir/lig* $resdir/z* $resdir/t*
+
+    ######### outfr.dat
+    if [[ "$frameFirst" -eq "first" ]]; then
+      frameFirst=1
+    fi
+
+    if [[ "$frameLast" -eq "last" ]]; then
+      frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
+    fi
+
+    KK=0
+    for traj in $DCD
+    do
+      for (( nn = $frameFirst ; nn <= $frameLast   ; nn++ ))
+      do
+        CRAT=`awk '{if (\$2 == "'"$KK"'" && \$4 == "'"$nn"'" ) print }' ___tttt | wc -l | awk '{print $1}'`
+
+        if [ $CRAT -ge 1 ]; then
+          PROBID=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $8}'`
+          PROBNU=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $9}'`
+          echo "SIM# $KK FRAME# $nn PROBE $PROBID PROBE# $PROBNU "  >> $resdir/outfr.dat
+        fi
+      done
+      ((KK++))
+    done
+    rm _*
+    #########
+
+    mv $resdir $FOUTDIR/
+
+    done
+    rm _*
+  done
 done
-#### Sort
 
-wc -l $resdir/out-$FF.dat  >> $resdir/out-count
-cat $resdir/out-$FF.dat  >> ___tttt            
-
-done
-
-#########
-rm    $resdir/v*pdb $resdir/lig* $resdir/z* $resdir/t*
-
-######### outfr.dat
-for KK in $TRJNUM
-do
-for (( nn = 0   ; nn <= $FRANUM   ; nn++ ))
-do
-cat > _molexe  <<EOF
-awk '{if (\$2 == $KK && \$4 == $nn ) print }' ___tttt  > ___tttt2
-EOF
-chmod 777 _molexe
-./_molexe
-rm _molexe
-
-CRAT=`wc -l ___tttt2 | awk '{print $1}'`
-
-if [ $CRAT -ge 1 ]; then
-grep "$KK $nn" $resdir/out-res-*.dat > ____tttt
-PROBID=`head -n 1 ____tttt | awk '{print $8}'`
-PROBNU=`head -n 1 ____tttt | awk '{print $9}'`
-echo "SIM# $KK FRAME# $nn PROBE $PROBID PROBE# $PROBNU "  >> ___tttt3
-fi
-done
-done
-mv ___tttt3 $resdir/outfr.dat
-rm _*
-#########
-
-mv $resdir snapshot-$FOUTDIR/
-
-done
-rm _*
-done
-done
-
-wc -l snapshot-$FOUTDIR/z.*.*/outfr*  >  ___tttt4
-grep -v "total" ___tttt4              >  ___tttt5
-sort -r -n -k1  ___tttt5              >  ___tttt6
-cp ___tttt6 snapshot-$FOUTDIR/zlist-count
+wc -l $FOUTDIR/z.*.*/outfr* | grep -v "total" | sort -r -n -k1 > $FOUTDIR/zlist-count
 
 rm __*
 

--- a/snapshotstatistics.sh
+++ b/snapshotstatistics.sh
@@ -73,12 +73,12 @@ if [[ $1 = "help" ]]; then
 fi
 
 # Set DCD, PDB, CHAIN and PROBE
-if [[ DCD != "*dcd" ]]; then
+if [[ DCD != *dcd ]]; then
   DCD=`cat $DCD` || DCD=$DCD
 fi
 DCD=`echo $DCD | sed 's/ /,/'`
 
-if [[ PDB != "*pdb" ]]; then
+if [[ PDB != *pdb ]]; then
   PDB=`cat $PDB` || PDB=$PDB
 fi
 PDB=`echo $PDB | sed 's/ /,/'`
@@ -140,7 +140,12 @@ do
     for FPROBE in $PROBE
     do
 
-    grep "$FPROBE $FCHAIN" highaffresid/$FINDIR/highaffresid2.dat > ____tt
+    if [[ $FINDIR == highaffresid* ]]; then
+      grep "$FPROBE $FCHAIN" $FINDIR/highaffresid2.dat > ____tt
+    else
+      grep "$FPROBE $FCHAIN" highaffresid/$FINDIR/highaffresid2.dat > ____tt
+    fi
+
     sed -e "s/$FPROBE $FCHAIN/    /g" ____tt > ____tt1
     RESID=`cat ____tt1 | awk '{print $0}'`
 
@@ -163,7 +168,12 @@ do
       rm -r __run
       ###############################
 
-      grep $FPROBE highaffresid/$FINDIR/hotspots2.pdb | sort -n -k10 > __test1
+      if [[ $FINDIR == highaffresid* ]]; then
+        grep $FPROBE $FINDIR/hotspots2.pdb | sort -n -k10 > __test1
+      else
+        grep $FPROBE highaffresid/$FINDIR/hotspots2.pdb | sort -n -k10 > __test1
+      fi
+      
 
       TNUM=`wc -l __test1 | awk '{print $1}'`
 
@@ -246,7 +256,7 @@ do
 
       ######### outfr.dat
       if [[ "$frameFirst" -eq "first" ]]; then
-        frameFirst=1
+        frameFirst=0
       fi
 
       if [[ "$frameLast" -eq "last" ]]; then

--- a/snapshotstatistics.sh
+++ b/snapshotstatistics.sh
@@ -19,13 +19,13 @@ DCD='traj-list.dat'
 CHAIN='chain-list.dat'
 # probe molecule ID in pdb
 PROBE='probe-list.dat' 
-# first frame number for each dcd 
+# first frame number for each trajectory 
 frameFirst='first'
-# last frame number for each dcd        
+# last frame number for each trajectory        
 frameLast='last'
 ######### Check here  #######
 
-for arg in `seq 1 "$#"`; 
+for arg in `seq 1 "$#"`; do
   if [[ "$arg" -eq 1 ]]; then
     INDIR=$1
   elif [[ "$arg" -eq 2 ]]; then
@@ -93,7 +93,7 @@ fi
 
 IFS=','
 INDIRS=()
-for $indir in $INDIR; do
+for indir in $INDIR; do
   INDIRS+=($indir)
 done
 INDIR=${INDIRS[@]}
@@ -110,9 +110,10 @@ do
     for FPROBE in $PROBE
     do
 
-    grep "$FPROBE $FCHAIN" $INDIR/highaffresid2.dat > ____tt
+    grep "$FPROBE $FCHAIN" highaffresid/$FINDIR/highaffresid2.dat > ____tt
     sed -e "s/$FPROBE $FCHAIN/    /g" ____tt > ____tt1
     RESID=`cat ____tt1 | awk '{print $0}'`
+
 
     for EE in $RESID
     do
@@ -122,136 +123,136 @@ do
       mkdir __run
       cd __run
       env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot1.tcl -args ../$PDB ../$DCD $CUTOFF $FPROBE $EE $FCHAIN
-    done
-
-    mv  __run/ligbo*  $resdir
-    cat __run/v*pdb > $resdir/v-com.pdb
-    ls  __run/v*pdb >  __test
-    awk '{print $1, (NR-1) }' __test > $resdir/zlist
-
-    rm -r __run
-    ###############################
-
-    grep $FPROBE $INDIR/hotspots2.pdb | sort -n -k10 > __test1
-
-    TNUM=`wc -l __test1 | awk '{print $1}'`
-
-    echo "/END/{i\\" > __test3
-
-    for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
-    do
-      sed -n -e "$mm,$mm p" __test1 > __test2
-
-      awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", \$6, \$7, \$8, \$9, \$10, "M\\\" )}' \
-      __test2 >> __test3
-      awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", \$6, \$7, \$8, \$9, \$10, "M" )}' \
-      __test2 >> __ttest3
-
-    done
-
-    cp __ttest3 $resdir/hot-spot.pdb
-
-    echo "END " >> __test3
-    echo "d "   >> __test3
-    echo "} "   >> __test3
-
-    sed -f __test3  $resdir/v-com.pdb > $resdir/v-com-ok.pdb
-    rm _*
-
-    #########
-    for (( FF = 1 ; FF <= $TNUM  ; FF++ ))
-    do
-      cd $resdir
-
-      env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot2.tcl -args $CUTOFF2 $FPROBE $FF
-
-      mv _ligbo-ok.dat ligbo-ok.$FF.dat
-
-      TNNN=`wc -l zlist | awk '{print $1}'`
-
-      for (( rr = 0   ; rr <= $TNNN     ; rr++ ))
-      do
-
-        awk '{if (\$1 == "'"$rr"'") print }' ligbo-ok.$FF.dat > ___test2
-
-        CRAT=`wc -l ___test2 | awk '{print $1}'`
-
-        if [ $CRAT -ge 1 ]; then
-          awk '{if (\$2 == "'"$rr"'") print }' zlist  > ___test3
-
-          perl -i -pe 's/-/ /g' ___test3
-          perl -i -pe 's/.pdb/    /g' ___test3
-
-          FRAMT=`cat ___test3 | awk '{print $2}'`
-          FRAME=`cat ___test3 | awk '{print $3}'`
-          FRAMM=`cat ___test3 | awk '{print $4}'`
-
-          awk '{if (\$1 == "'"$FRAMM"'") print "'"$FRAMT"'" , "'"$FRAME"'" , \$3, \$4, \$5, \$7, \$8, \$10 }' ligbo-ok.$FF.dat >> tout-hotspot-$FF.dat
-          awk '{if (\$1 == "'"$FRAME"'") print "'"$FRAMT"'" , \$0 }' ligbo-$FRAMT.dat        >> tout-res-$FF.dat
-
-          awk '{print "SIM#", $2, "FRAME#", $3 }' ___test3 >> tout-$FF.dat
-        fi
-
-      done
-
-      rm _*
       cd ..
 
-      #### Sort
+      mv  __run/ligbo*  $resdir/
+      cat __run/v*pdb > $resdir/v-com.pdb
+      ls  __run/v*pdb >  __test
+      awk '{print $1, (NR-1) }' __test > $resdir/zlist
+
+      rm -r __run
+      ###############################
+
+      grep $FPROBE highaffresid/$FINDIR/hotspots2.pdb | sort -n -k10 > __test1
+
+      TNUM=`wc -l __test1 | awk '{print $1}'`
+
+      echo "/END/{i\\" > __test3
+
+      for (( mm = 1 ; mm <= $TNUM  ; mm++ ))
+      do
+        sed -n -e "$mm,$mm p" __test1 > __test2
+
+        awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", $6, $7, $8, $9, $10, "M\\" )}' \
+        __test2 >> __test3
+        awk '{printf("%-6s%5s  %-3s %4s%1s%4d %11.3f%8.3f%8.3f%6.2f%6.2f%13s\n", "ATOM", "'"'$mm'"'", "C2", "'"'$FPROBE'"'", "M", "'"'$mm'"'", $6, $7, $8, $9, $10, "M" )}' \
+        __test2 >> __ttest3
+      done
+
+      cp __ttest3 $resdir/hot-spot.pdb
+
+      echo "END " >> __test3
+      echo "d "   >> __test3
+      echo "} "   >> __test3
+
+      sed -f __test3  $resdir/v-com.pdb > $resdir/v-com-ok.pdb
+      rm _*
+
+      #########
+      for (( FF = 1 ; FF <= $TNUM  ; FF++ ))
+      do
+        cd $resdir
+
+        env VMDARGS='text with blanks' vmd -dispdev text -e $PHARMMAKER_HOME/snapshot2.tcl -args $CUTOFF2 $FPROBE $FF
+
+        mv _ligbo-ok.dat ligbo-ok.$FF.dat
+
+        TNNN=`wc -l zlist | awk '{print $1}'`
+
+        for (( rr = 0   ; rr <= $TNNN     ; rr++ ))
+        do
+
+          awk '{if ($1 == "'"$rr"'") print }' ligbo-ok.$FF.dat > ___test2
+
+          CRAT=`wc -l ___test2 | awk '{print $1}'`
+
+          if [ $CRAT -ge 1 ]; then
+            awk '{if ($2 == "'"$rr"'") print }' zlist  > ___test3
+
+            perl -i -pe 's/-/ /g' ___test3
+            perl -i -pe 's/.pdb/    /g' ___test3
+
+            FRAMT=`cat ___test3 | awk '{print $2}'`
+            FRAME=`cat ___test3 | awk '{print $3}'`
+            FRAMM=`cat ___test3 | awk '{print $4}'`
+
+            awk '{if ($1 == "'"$FRAMM"'") print "'"$FRAMT"'" , "'"$FRAME"'" , $3, $4, $5, $7, $8, $10 }' ligbo-ok.$FF.dat >> tout-hotspot-$FF.dat
+            awk '{if ($1 == "'"$FRAME"'") print "'"$FRAMT"'" , $0 }' ligbo-$FRAMT.dat        >> tout-res-$FF.dat
+
+            awk '{print "SIM#", $2, "FRAME#", $3 }' ___test3 >> tout-$FF.dat
+          fi
+
+        done
+
+        rm _*
+        cd ..
+
+        #### Sort
+        KK=0
+        for traj in $DCD; do
+          awk '{if ($2 == "'"$KK"'") print }' $resdir/tout-$FF.dat | sort -n -k4 >> $resdir/out-$FF.dat
+          awk '{if ($1 == "'"$KK"'") print }' $resdir/tout-res-$FF.dat | sort -n -k2 >> $resdir/out-res-$FF.dat
+          awk '{if ($1 == "'"$KK"'") print }' $resdir/tout-hotspot-$FF.dat | sort -n -k2 >> $resdir/out-hotspot-$FF.dat 
+          ((KK++))
+        done
+        #### Sort
+
+        wc -l $resdir/out-$FF.dat  >> $resdir/out-count
+        cat $resdir/out-$FF.dat  >> ___tttt            
+
+      done
+
+      #########
+
+      rm    $resdir/v*pdb $resdir/lig* $resdir/z* $resdir/t*
+
+      ######### outfr.dat
+      if [[ "$frameFirst" -eq "first" ]]; then
+        frameFirst=1
+      fi
+
+      if [[ "$frameLast" -eq "last" ]]; then
+        frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
+      fi
+
       KK=0
-      for traj in $DCD; do
-        awk '{if (\$2 == "'"$KK"'") print }' $resdir/tout-$FF.dat | sort -n -k4 >> $resdir/out-$FF.dat
-        awk '{if (\$1 == "'"$KK"'") print }' $resdir/tout-res-$FF.dat | sort -n -k2 >> $resdir/out-res-$FF.dat
-        awk '{if (\$1 == "'"$KK"'") print }' $resdir/tout-hotspot-$FF.dat | sort -n -k2 >> $resdir/out-hotspot-$FF.dat 
+      for traj in $DCD
+      do
+        for (( nn = $frameFirst ; nn <= $frameLast   ; nn++ ))
+        do
+          CRAT=`awk '{if ($2 == "'"$KK"'" && $4 == "'"$nn"'" ) print }' ___tttt | wc -l | awk '{print $1}'`
+
+          if [ $CRAT -ge 1 ]; then
+            PROBID=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $8}'`
+            PROBNU=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $9}'`
+            echo "SIM# $KK FRAME# $nn PROBE $PROBID PROBE# $PROBNU "  >> $resdir/outfr.dat
+          fi
+        done
         ((KK++))
       done
-      #### Sort
+      rm _*
+      #########
 
-      wc -l $resdir/out-$FF.dat  >> $resdir/out-count
-      cat $resdir/out-$FF.dat  >> ___tttt            
+      mv $resdir $FOUTDIR/
 
-    done
-
-    #########
-
-    rm    $resdir/v*pdb $resdir/lig* $resdir/z* $resdir/t*
-
-    ######### outfr.dat
-    if [[ "$frameFirst" -eq "first" ]]; then
-      frameFirst=1
-    fi
-
-    if [[ "$frameLast" -eq "last" ]]; then
-      frameLast=`tail -n1 $resdir/out-?.dat | sort -n -k4 | tail -n1 | awk '{ print $NF }'`
-    fi
-
-    KK=0
-    for traj in $DCD
-    do
-      for (( nn = $frameFirst ; nn <= $frameLast   ; nn++ ))
-      do
-        CRAT=`awk '{if (\$2 == "'"$KK"'" && \$4 == "'"$nn"'" ) print }' ___tttt | wc -l | awk '{print $1}'`
-
-        if [ $CRAT -ge 1 ]; then
-          PROBID=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $8}'`
-          PROBNU=`grep "$KK $nn" $resdir/out-res-*.dat | head -n 1 | awk '{print $9}'`
-          echo "SIM# $KK FRAME# $nn PROBE $PROBID PROBE# $PROBNU "  >> $resdir/outfr.dat
-        fi
       done
-      ((KK++))
+      rm _*
     done
-    rm _*
-    #########
 
-    mv $resdir $FOUTDIR/
-
-    done
-    rm _*
   done
-done
 
-wc -l $FOUTDIR/z.*.*/outfr* | grep -v "total" | sort -r -n -k1 > $FOUTDIR/zlist-count
+  wc -l $FOUTDIR/z.*.*/outfr* | grep -v "total" | sort -r -n -k1 > $FOUTDIR/zlist-count
 
-rm __*
+  rm __*
 
 done


### PR DESCRIPTION
The way it works now is as follows (numbering steps as in the paper with step 1 being DruGUI):

2. highaffresid.tcl makes a directory **highaffresid**
- it can optionally create subdirectories inside **highaffresid** for sites (or other regions of interest) and store them in _site-list.dat_ but usually we don't use it like that.

3. siteselection.sh makes its own directories inside the directories from the previous step for each site and puts them in _site-list2.dat_ - usually this means something like **highaffresid/dg_site_1**
- if there are subdirectories in _site-list.dat_ then they would be taken into account and we could have something like **highaffresid/dg_site_1/dg_site_1**

4. snapshotstatistics.sh makes a directory **snapshot** and then it takes the last part of each directory in _site-list2.dat_  to make subdirectories to put its results in so we get **snapshot/dg_site_1**. It then has subdirectories inside there for chains, resids and probes e.g. **snapshot/dg_site_1/z.A.218.ACAM** for detailed results.

5. snapshotselection.sh also reads  _site-list2.dat_  and uses that information in the same way to find the directory with the snapshots results and particularly _zlist-count_

I think this works now but I still need to test snapshotselection once snapshotstatistics finishes.